### PR TITLE
reset variable to h3

### DIFF
--- a/pxutils.go
+++ b/pxutils.go
@@ -23,7 +23,7 @@ func h1(n string, t string) string {
 	o := make([]int, 16)
 	i := make([]int, 16)
 	if len(r) > 16 {
-		h3(r, 8*len(t))
+		r = h3(r, 8*len(t))
 	}
 	for e = 0; e < 16; e++ {
 		if e >= len(r) {


### PR DESCRIPTION
When the size of the r is >16, we need to change the variable to h3, and not just execute h3.

That fix error when trying to generate PX357-9.